### PR TITLE
Improvements

### DIFF
--- a/isInViewport.js
+++ b/isInViewport.js
@@ -5,22 +5,33 @@ function isInViewport() {
 
   function __inView(el) {
     var bounds = el.getBoundingClientRect();
-    return bounds.top < window.innerHeight && bounds.bottom > 0;
+    return bounds.top < window.innerHeight && bounds.bottom > 0 && bounds.left < window.innerWidth && bounds.right > 0;
   }
 
   var self = {
     inView: function(el, cb) {
-      for (var i=0; i<el.length; i++) {
-        if (__inView(el[i])) {
-          return cb(el);
+      if (el instanceof NodeList) {
+        for (var i=0; i<el.length; i++) {
+          if (__inView(el[i])) {
+            cb(el);
+          }
         }
+      } else if (__inView(el)) {
+        cb(el);
       }
+      return el;
     },
     isInView: function(el) {
-      for (var i=0; i<el.length; i++) {
-        return __inView(el[i]);
-      };
-
+      if (el instanceof NodeList) {
+        for (var i=0; i<el.length; i++) {
+          if (!__inView(el[i])) {
+            return false;
+          }
+        }
+        return true;
+      } else {
+        return __inView(el);
+      }
     },
   };
   return self;


### PR DESCRIPTION
- added horizontal scroll support
- both functions now support single elements from `document.querySelector()`
- `inView` calls the callback for _each_ element in the list, instead of only the first
- `isInView` only returns `true` when _all_ elements in the list are in view

Note: this breaks compatibility with jQuery and other such libraries that do not return a `NodeList`. We cannot rely on checking for a `length` property because `document.querySelector("select").length` returns the number of `<option>` elements.

The conditions for single elements could be changed to:

``` js
if (el instanceof Element)
```

Is it really necessary to support third-party libraries? They could just use an `$.each()` (or similar).
